### PR TITLE
TOPページ以外での背景画像のスタイルを調整

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -4,23 +4,33 @@
 html,
 body,
 div.wrapper {
+  position: relative;
   height: 100%;
+  z-index: 0;
+  overflow-y: scroll;
 }
 
-@media screen and (orientation: portrait) {
-  body {
+body::before {
+  content: '';
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100vh;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+
+  @media screen and (orientation: portrait) {
     background-image: image-url("IMG_9310.jpg");
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-position: center;
   }
-}
 
-@media screen and (orientation: landscape) {
-  body {
+  @media screen and (orientation: landscape) {
     background-image: image-url("IMG_9862.JPG");
-    background-size: cover;
-    background-repeat: no-repeat;
   }
 }
 


### PR DESCRIPTION
## 概要

要素が画面サイズからはみ出た時に背景画像が途切れる現象を修正

### 内容

- メディアクエリ部分で擬似要素としてのブロック要素を作り、背景画像を表示
- 背景画像を表示しているブロック要素自体を固定し、後ろに配置