### PR TITLE
空投稿できないように送信ボタンを無効化

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,3 +7,34 @@ require("bootstrap/dist/js/bootstrap");
 require("@fortawesome/fontawesome-free/js/all")
 require("trix");
 require("@rails/actiontext");
+
+
+document.addEventListener('turbolinks:load', () => {
+  const formTitle = document.getElementById('post_title')
+  const formContent = document.getElementById('post_content')
+  const btn = document.getElementById("btn")
+
+  if (formTitle) {
+    [formTitle, formContent].forEach((form) => {
+      form.addEventListener('keyup', () => {
+        btn.disabled = !(formTitle.value && formContent.value)
+      })
+    })
+
+    // 1.<formTitle>
+    // formTitle.addEventListener('keyup', () => {
+    // if (formTitle.value && formContent.value) {
+    //   btn.disabled = false
+    // } else {
+    //   btn.disabled = true
+    // }
+    // 上記のif文を簡潔に
+    //   btn.disabled = !(formTitle.value && formContent.value)
+    // })
+    // 
+    // 2.<formContent> 上に同じ
+    // formContent.addEventListener('keyup', () => {
+    //   btn.disabled = !(formTitle.value && formContent.value)
+    // })
+  }
+})

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="container-fluid mt-5" style="max-width: 800px;">
   <%= form_with model: @post, local: true do |f| %>
-    <p><%= f.label :title, "タイトル" %> <%= f.text_area :title %></p>
+    <p><%= f.label :title %> <%= f.text_area :title %></p>
     <%= f.rich_text_area :content %>
     <p><%= f.submit "送信" %></p>
   <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,6 +2,6 @@
   <%= form_with model: @post, local: true do |f| %>
     <p><%= f.label :title %> <%= f.text_area :title %></p>
     <%= f.rich_text_area :content %>
-    <p><%= f.submit "送信" %></p>
+    <p><%= f.submit "送信", id: 'btn', disabled: true %></p>
   <% end %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,10 @@ ja:
       previous: <i class="fas fa-angle-left"></i>
       next: <i class="fas fa-angle-right"></i>
       truncate: "..."
+  activerecord:
+    models:
+      post: メッセージ
+    attributes:
+      post:
+        title: タイトル
+        content: 本文


### PR DESCRIPTION
## 内容

- `disabled` で送信ボタンを無効化
- タイトルと内容両方が入力されたときにボタンを有効化
- エラーメッセージを日本語化し、ラベルに適用